### PR TITLE
Fix readStream authentication/access token

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -29,7 +29,7 @@ class GoogleDriveAdapter extends AbstractAdapter
     const FETCHFIELDS_GET = 'id,name,mimeType,modifiedTime,parents,permissions,size,webContentLink,webViewLink';
 
     /**
-     * MIME type of directory
+     * MIME tyoe of directory
      *
      * @var string
      */
@@ -385,9 +385,17 @@ class GoogleDriveAdapter extends AbstractAdapter
             if ($file = $this->getFileObject($path)) {
                 $dlurl = $this->getDownloadUrl($file);
                 $client = $this->service->getClient();
-                $token = $client->getAccessToken();
+                try {
+                    $token = $client->fetchAccessTokenWithAssertion();
+                } catch (\DomainException $e) {
+                    $token = $client->getAccessToken();
+                }
                 $access_token = '';
                 if (is_array($token)) {
+                    if (empty($token['access_token'])) {
+                        $token = $client->fetchAccessTokenWithRefreshToken();
+
+                    }
                     $access_token = $token['access_token'];
                 } else {
                     if ($token = @json_decode($client->getAccessToken())) {
@@ -458,7 +466,6 @@ class GoogleDriveAdapter extends AbstractAdapter
                 return compact('stream');
             }
         }
-
         return false;
     }
 

--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -385,16 +385,15 @@ class GoogleDriveAdapter extends AbstractAdapter
             if ($file = $this->getFileObject($path)) {
                 $dlurl = $this->getDownloadUrl($file);
                 $client = $this->service->getClient();
-                try {
+                if ($client->isUsingApplicationDefaultCredentials())
                     $token = $client->fetchAccessTokenWithAssertion();
-                } catch (\DomainException $e) {
+                } else {
                     $token = $client->getAccessToken();
                 }
                 $access_token = '';
                 if (is_array($token)) {
-                    if (empty($token['access_token'])) {
+                    if (empty($token['access_token']) && !empty($token['refresh_token'])) {
                         $token = $client->fetchAccessTokenWithRefreshToken();
-
                     }
                     $access_token = $token['access_token'];
                 } else {


### PR DESCRIPTION
Addresses two failings:
- I use a service account, it was unable to retrieve an access token in this situation.
- When using regular oauth creds with a refresh token, it made no attempt to refresh / obtain an access token if one isn't there