### PR TITLE
Removed undeclared root property

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -115,14 +115,14 @@ class GoogleDriveAdapter extends AbstractAdapter
      *
      * @var string
      */
-    private $fetchfieldsGet = '';
+    private $fetchfieldsGet;
 
     /**
      * List of fetch field for lest
      *
      * @var string
      */
-    private $fetchfieldsList = '';
+    private $fetchfieldsList;
 
     /**
      * Additional fetch fields array
@@ -147,12 +147,8 @@ class GoogleDriveAdapter extends AbstractAdapter
 
     public function __construct(Google_Service_Drive $service, $root = null, $options = [])
     {
-        if (! $root) {
-            $root = 'root';
-        }
         $this->service = $service;
-        $this->setPathPrefix($root);
-        $this->root = $root;
+        $this->setPathPrefix($root !== null ? $root : 'root');
 
         $this->options = array_replace_recursive(static::$defaultOptions, $options);
 


### PR DESCRIPTION
The `root` property is written in the constructor but never read anywhere in the application: it is redundant. Moreover, the `root` field was never declared as a member of the class, which incurs a performance hit when it is first written. Additionally, this fixes a subtle bug where `$root` could be set to a falsy value (e.g. `"0"`) and would be overwritten with the default (`'root'`).

However, in my testing it appears the *path prefix* feature is completely broken, anyway, and should probably just be removed. That is, setting the path prefix has no effect on where files are written to.

---
As a bonus, I removed the field initializers for two properties that are unconditionally set at construct time anyway (they are overwritten before their defaults could ever be used).