### PR TITLE
Only use team drive as root if no root folder was specified

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -1289,8 +1289,10 @@ class GoogleDriveAdapter extends AbstractAdapter
                 'teamDriveId' => $teamDriveId
             ]
         ]);
-
-        $this->setPathPrefix($teamDriveId);
-        $this->root = $teamDriveId;
+        
+        if ($this->root === 'root') {
+            $this->setPathPrefix($teamDriveId);
+            $this->root = $teamDriveId;
+        }
     }
 }


### PR DESCRIPTION
This fixes https://github.com/nao-pon/flysystem-google-drive/issues/41