### PR TITLE
Fix upload file Google_Service_Exception

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -999,12 +999,17 @@ class GoogleDriveAdapter extends AbstractAdapter
             'fields' => $this->fetchfieldsGet
         ];
 
-        $results[] = $this->service->files->get($itemId, $this->applyDefaultParams($opts, 'files.get'));
-        if ($checkDir && $this->useHasDir) {
-            $results[] = $service->files->listFiles($this->applyDefaultParams([
-                'pageSize' => 1,
-                'q' => sprintf('trashed = false and "%s" in parents and mimeType = "%s"', $itemId, self::DIRMIME)
-            ], 'files.list'));
+        try {
+            $results[] = $this->service->files->get($itemId, $this->applyDefaultParams($opts, 'files.get'));
+            if ($checkDir && $this->useHasDir) {
+                $results[] = $service->files->listFiles($this->applyDefaultParams([
+                    'pageSize' => 1,
+                    'q' => sprintf('trashed = false and "%s" in parents and mimeType = "%s"', $itemId, self::DIRMIME)
+                ], 'files.list'));
+            }
+        }
+        catch (\Google_Service_Exception $exception) {
+            return NULL;
         }
 
         list ($fileObj, $hasdir) = array_pad($results, 2, null);


### PR DESCRIPTION
Related to: https://github.com/nao-pon/flysystem-google-drive/issues/78

**After thorough debugging with xdebug and a proxy I have found the following.**

When uploading a file it seems that the code is checking whether that [file exists](https://github.com/nao-pon/flysystem-google-drive/blob/2bf6a4998f157a1fd34487a499072eec3236e274/src/GoogleDriveAdapter.php#L1174).

Flysystem tries to see if it will [write or update the stream](https://github.com/thephpleague/flysystem/blob/e0fed6884facb208b353ba738d8a47b147d786e3/src/Filesystem.php#L118) `public function Filesystem::putStream($path, $resource, array $config = []) bool`

If I am not mistaken, the file gets created and then the data gets uploaded.  When using `batch` and we check whether the file exists the API sends back a `200 Response` with a `404` error within - that allows the code execution to continue.  On the contrary with 2bf6a49 when we try to use the same code we get a `404 Response` and the application throws a `Google_Service_Exception` [exception](https://github.com/googleapis/google-api-php-client/blob/8e9215910703f72b29f50d3aa7f67545f4c56ff4/src/Google/Http/REST.php#L123)

While in the `batch` the code will continue to execute. In the 2bf6a49, the exception stops any subsequent requests to upload the file.

## One of the Batch Requests
```
POST https://www.googleapis.com/batch/drive/v3 HTTP/1.1
Host: www.googleapis.com
...
GET /drive/v3/files/filename.pptx?fields=id%2Cname%2CmimeType%2CmodifiedTime%2Cparents%2Cpermissions%2Csize%2CwebContentLink%2CwebViewLink HTTP/1.1
...
```

## 200 Response with a 404 inside
```
HTTP/1.1 200 OK
...

29a
--batch_xxxxxxxxxxxxxxxxxxxxxxx
Content-Type: application/http
Content-ID: response-obj

HTTP/1.1 404 Not Found
...

{
 "error": {
  "errors": [
   {
    "domain": "global",
    "reason": "notFound",
    "message": "File not found: filename.pptx.",
    "locationType": "parameter",
    "location": "fileId"
   }
  ],
  "code": 404,
  "message": "File not found: filename.pptx."
 }
}

--batch_yyyyyyyyyyyyyyyyyyyyyyyy-
```

## 2bf6a49 Request returns 404 and not 200, application throws a `Google_Service_Exception`
```
GET https://www.googleapis.com/drive/v3/files/filename.pptx?fields=id%2Cname%2CmimeType%2CmodifiedTime%2Cparents%2Cpermissions%2Csize%2CwebContentLink%2CwebViewLink HTTP/1.1
...

# 404 Response
HTTP/1.1 404 Not Found

14a
{
 "error": {
  "errors": [
   {
    "domain": "global",
    "reason": "notFound",
    "message": "File not found: filename.pptx.",
    "locationType": "parameter",
    "location": "fileId"
   }
  ],
  "code": 404,
  "message": "File not found: filename.pptx."
 }
}
```

## Fix
Wrapping [these lines](https://github.com/nao-pon/flysystem-google-drive/blob/2bf6a4998f157a1fd34487a499072eec3236e274/src/GoogleDriveAdapter.php#L1002-L1008) in a try catch block seems to work.  This allows for the file upload to work.  Let me know if this is not the ideal solution.
```
try {
  $results[] = $this->service->files->get($itemId, $this->applyDefaultParams($opts, 'files.get'));

  if ($checkDir && $this->useHasDir) {
    $results[] = $service->files->listFiles($this->applyDefaultParams([
      'pageSize' => 1,
      'q' => sprintf('trashed = false and "%s" in parents and mimeType = "%s"', $itemId, self::DIRMIME)
    ], 'files.list'));
  }
}
catch (\Google_Service_Exception $e){
  // Do nothing or something but deal with the Exception and continue
  return NULL; // skips the code below which would return NULL anyway
}
```