### PR TITLE
Added formal delcaration for dynamic property: "root"

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -43,6 +43,13 @@ class GoogleDriveAdapter extends AbstractAdapter
     protected $service;
 
     /**
+     * Root directory
+     *
+     * @var string
+     */
+    public $root;
+
+    /**
      * Default options
      *
      * @var array


### PR DESCRIPTION
The `root` property has always existed in `GoogleDriveAdapter`, but it was declared dynamically at run-time, instead of formally at compile time. This causes errors in newer versions of PHP, such as the following.

>PHP Deprecated:  Creation of dynamic property Hypweb\Flysystem\GoogleDrive\GoogleDriveAdapter::$root is deprecated in nao-pon\flysystem-google-drive\src\GoogleDriveAdapter.php on line 164

It is highly unlikely we would want this property to be public if it had been designed correctly from the beginning, but for backwards compatibility, this is the only correct visibility modifier.